### PR TITLE
feat: add metadata field to modules.json

### DIFF
--- a/src/pack.test.ts
+++ b/src/pack.test.ts
@@ -14,14 +14,12 @@ test('Pack', async () => {
             name: 'c',
             sourceDir: './c',
         }],
-        metadata: {
-            "version": "0.8.0"
-        }
+        metadata: { version: '0.8.0' },
     });
 
     expect(result.fullHash).toBe('7a8192768029ad9bd0aff064df12568aeea22573fe12eda88898687232e8cefdb759bf2cbd7795fa5840be1c6886025b86d621c76869df996a18260c535c761c');
     expect(result.base.hash).toBe('c66ac1e5c010060c460d72ee94034f0fff3dffc9ef762502611876fcba444c9d7b5a761952a906175db7e96243b8d93651a0468d3e768709eb7895f36c35ad67');
     expect(result.base.files).toEqual(['a.json', 'module.json']);
     expect(result.modules).toHaveLength(3);
-    expect(result.metadata).toEqual(expect.objectContaining({"version": "0.8.0"}));
+    expect(result.metadata).toEqual(expect.objectContaining({ version: '0.8.0' }));
 });

--- a/src/pack.test.ts
+++ b/src/pack.test.ts
@@ -23,5 +23,5 @@ test('Pack', async () => {
     expect(result.base.hash).toBe('c66ac1e5c010060c460d72ee94034f0fff3dffc9ef762502611876fcba444c9d7b5a761952a906175db7e96243b8d93651a0468d3e768709eb7895f36c35ad67');
     expect(result.base.files).toEqual(['a.json', 'module.json']);
     expect(result.modules).toHaveLength(3);
-    expect(result.metadata).toEqual(expect.objectContaining({"version": "0.8.0"}))
+    expect(result.metadata).toEqual(expect.objectContaining({"version": "0.8.0"}));
 });

--- a/src/pack.test.ts
+++ b/src/pack.test.ts
@@ -14,10 +14,14 @@ test('Pack', async () => {
             name: 'c',
             sourceDir: './c',
         }],
+        metadata: {
+            "version": "0.8.0"
+        }
     });
 
     expect(result.fullHash).toBe('7a8192768029ad9bd0aff064df12568aeea22573fe12eda88898687232e8cefdb759bf2cbd7795fa5840be1c6886025b86d621c76869df996a18260c535c761c');
     expect(result.base.hash).toBe('c66ac1e5c010060c460d72ee94034f0fff3dffc9ef762502611876fcba444c9d7b5a761952a906175db7e96243b8d93651a0468d3e768709eb7895f36c35ad67');
     expect(result.base.files).toEqual(['a.json', 'module.json']);
     expect(result.modules).toHaveLength(3);
+    expect(result.metadata).toEqual(expect.objectContaining({"version": "0.8.0"}))
 });

--- a/src/packer.ts
+++ b/src/packer.ts
@@ -105,6 +105,7 @@ export const pack = async (buildManifest: BuildManifest): Promise<DistributionMa
         fs.copySync(buildManifest.baseDir, tempDir);
 
         const distributionManifest: DistributionManifest = {
+            metadata: buildManifest.metadata,
             modules: [],
             base: {
                 hash: '',

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,12 +7,14 @@ export interface BuildManifest {
     baseDir: string;
     outDir: string;
     modules: Module[];
+    metadata?: any;
 }
 
 export interface DistributionManifest {
     modules: DistributionModule[];
     base: Base;
     fullHash: string;
+    metadata?: any;
 }
 
 export interface InstallManifest extends DistributionManifest {


### PR DESCRIPTION
This adds an optional `metadata` field to the `modules.json` file in order to make version detection easier